### PR TITLE
clang build fix. closes #36

### DIFF
--- a/src/rt_playr.c
+++ b/src/rt_playr.c
@@ -2750,7 +2750,7 @@ boolean GiveBulletWeapon(objtype *ob,int bulletweapon,statobj_t*check)
 
 }
 
-inline boolean DetermineAmmoPickup(playertype *pstate, statobj_t *check)
+boolean DetermineAmmoPickup(playertype *pstate, statobj_t *check)
 {
     if ((GetWeaponForItem(check->itemnumber) == pstate->missileweapon) &&
             (pstate->ammo < stats[check->itemnumber].ammo))


### PR DESCRIPTION
Remove unnecessary `inline`

Also mentioned in https://github.com/LTCHIPS/rottexpr/pull/18#issuecomment-615784973