### PR TITLE
floor rendering fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+
+*.rot
+build/
+.vscode/

--- a/src/w_wad.c
+++ b/src/w_wad.c
@@ -17,7 +17,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 // W_wad.c
 
-#include <alloca.h>
+#if defined(_MSC_VER) || defined(__MINGW32__)
+#include <malloc.h>     // alloca
+#else
+#include <alloca.h>     // alloca
+#endif
 #include <stdio.h>
 #include <string.h>
 #include <fcntl.h>


### PR DESCRIPTION
The original code has insufficient precision in the xstep and ystep used for floor/ceiling. This lack of precision results in very visible error accumulating as DrawRow renders left to right. Look at the distortion on the right side in the original.
Original
![floorDistorted](https://user-images.githubusercontent.com/18518874/114317129-406fb280-9acc-11eb-9a7c-a20178429fd6.png)
Improved
![floorFixed](https://user-images.githubusercontent.com/18518874/114317138-4c5b7480-9acc-11eb-81da-332ead7883bf.png)

Credit to a 2019 [Kaiser](https://twitter.com/svkaiser/status/1178086659696599042?lang=en) tweet for pointing out the problem.

It would be nice if https://github.com/LTCHIPS/rottexpr/pull/42 went in ahead of this. I did a hackier work around the same mingw-w64 problem for w_wad.c.

